### PR TITLE
Add StarCraft II build order planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Pequeña colección de utilidades médicas publicada como sitio estático. El
   clínica de pacientes con traumatismo encéfalocraneano.
  - **Calculadora de dosis**: utilitario que calcula la dosis de paracetamol
    según el peso del paciente.
+- **StarCraft II Build Orders**: página para gestionar build orders y counters.
 
 Estas páginas pueden alojarse en GitHub Pages simplemente subiendo el contenido
 del repositorio y seleccionando la rama adecuada en la configuración del

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <ul class="list-group">
             <li class="list-group-item"><a href="pacientes_tec.html" class="text-decoration-none">Pacientes TEC</a></li>
             <li class="list-group-item"><a href="calculadora_dosis.html" class="text-decoration-none">Calculadora de dosis</a></li>
+             <li class="list-group-item"><a href="starcraft_build_orders.html" class="text-decoration-none">StarCraft II Build Orders</a></li>
         </ul>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>

--- a/starcraft.js
+++ b/starcraft.js
@@ -1,0 +1,70 @@
+const buildOrders = {
+  PvP: [
+    {
+      name: '4 Gate',
+      steps: ['Pylon 14', 'Gateway 16', 'Asimilador 17', 'Núcleo Cibernético 20'],
+      counters: ['Blink Stalkers', 'Drop de Inmortales']
+    },
+    {
+      name: 'Blink Stalker',
+      steps: ['Pylon 14', 'Gateway 16', 'Nexo 20', 'Forja 21'],
+      counters: ['Fénix', 'Chargelot + Archon']
+    }
+  ],
+  PvZ: [
+    {
+      name: 'Forge Fast Expand',
+      steps: ['Pylon en rampa', 'Forja', 'Nexo', 'Gateway'],
+      counters: ['Roach Rush', 'Hydra Timing']
+    },
+    {
+      name: 'Stargate Opening',
+      steps: ['Pylon', 'Gateway', 'Nexo', 'Stargate'],
+      counters: ['Muchas reinas', 'Spore Crawlers']
+    }
+  ],
+  PvT: [
+    {
+      name: '1 Gate Expand',
+      steps: ['Pylon 14', 'Gateway 16', 'Nexo 20', 'Núcleo Cibernético 21'],
+      counters: ['Widow Mine Drop', '3 Barracones']
+    },
+    {
+      name: 'Colossus Timing',
+      steps: ['Pylon', 'Gateway', 'Núcleo Cibernético', 'Robotics Facility', 'Coloso'],
+      counters: ['Producción de Vikings', 'EMP']
+    }
+  ]
+};
+
+function renderBuildOrders(matchup){
+  const container = document.getElementById('build-orders');
+  container.innerHTML = '';
+  if(!matchup) return;
+  buildOrders[matchup].forEach(order => {
+    const div = document.createElement('div');
+    div.className = 'mb-3';
+    const steps = order.steps.map(step => '<li>' + step + '</li>').join('');
+    div.innerHTML = '<h5>' + order.name + '</h5><ol>' + steps + '</ol><p><strong>Counters:</strong> ' + order.counters.join(', ') + '</p>';
+    container.appendChild(div);
+  });
+}
+
+document.getElementById('matchup').addEventListener('change', e => {
+  renderBuildOrders(e.target.value);
+});
+
+const counters = {
+  'zealot rush': 'Muro con zealots y focos en área',
+  'stalker blink': 'Observadores e inmortales',
+  'mass air': 'Fénix y Templarios Altos',
+  'roach rush': 'Inmortales y mejora +1 ataque',
+  'marine marauder': 'Colosos y campos de fuerza'
+};
+
+document.getElementById('counter-btn').addEventListener('click', () => {
+  const strat = document.getElementById('enemy-strategy').value.toLowerCase();
+  const res = counters[strat];
+  const container = document.getElementById('counter-result');
+  container.innerHTML = res ? '<div class="alert alert-success">Counter recomendado: ' + res + '</div>' : '<div class="alert alert-warning">No hay counter definido.</div>';
+});

--- a/starcraft_build_orders.html
+++ b/starcraft_build_orders.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>StarCraft II - Build Orders</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <h1 class="mb-4">StarCraft II - Build Orders</h1>
+    <div class="mb-3">
+      <label for="matchup" class="form-label">Elige enfrentamiento</label>
+      <select id="matchup" class="form-select">
+        <option value="">Seleccionar...</option>
+        <option value="PvP">Protoss vs Protoss</option>
+        <option value="PvZ">Protoss vs Zerg</option>
+        <option value="PvT">Protoss vs Terran</option>
+      </select>
+    </div>
+    <div id="build-orders" class="mb-4"></div>
+    <h2 class="h4">Buscador de counters</h2>
+    <div class="input-group">
+      <input type="text" id="enemy-strategy" class="form-control" placeholder="Estrategia enemiga (ej. mass air)">
+      <button class="btn btn-primary" id="counter-btn">Buscar</button>
+    </div>
+    <div id="counter-result" class="mt-3"></div>
+  </div>
+
+  <script src="starcraft.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add interactive StarCraft II build order and counter page
- Link new page from index and document in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e6d702250832cb7da473c9c62de43