### PR TITLE
Mejorar legibilidad del certificado médico

### DIFF
--- a/documentos_medicos.html
+++ b/documentos_medicos.html
@@ -122,11 +122,11 @@ function fechaActual() {
 
 function generarCertificado() {
     const doc = new jsPDF();
-    const margen = 25;
+    const margen = 30;
     doc.text(fechaActual(), 210 - margen, margen, { align: 'right' });
-    doc.setFontSize(14);
+    doc.setFontSize(16);
     doc.text('CERTIFICADO MEDICO', 105, margen + 10, { align: 'center' });
-    doc.setFontSize(12);
+    doc.setFontSize(14);
     const nombre = document.getElementById('certNombre').value;
     const rut = document.getElementById('certRut').value;
     const diag = document.getElementById('certDiag').value;
@@ -136,7 +136,7 @@ function generarCertificado() {
     const medico = document.getElementById('certMedico').value;
     const medRut = document.getElementById('certMedRut').value;
     const contenido = `
-        <div style="font-size:12px; line-height:1.6;">
+        <div style="font-size:14pt; line-height:1.6;">
             <p style="text-align: justify;">
                 Certifico que el paciente <b>${nombre}</b> de RUT <b>${rut}</b> fue evaluado y presenta diagnóstico de <b>${diag}</b>, y deberá guardar reposo entre el <b>${inicio}</b> y el <b>${fin}</b>. Extiendo este certificado para ser presentado en <b>${est}</b>.
             </p>
@@ -153,7 +153,7 @@ function generarCertificado() {
     doc.html(contenido, {
         x: margen,
         y: margen + 20,
-        width: 160,
+        width: 150,
         callback: function (doc) {
             doc.save('certificado_medico.pdf');
         }


### PR DESCRIPTION
## Summary
- Ajustar el cuerpo del certificado a 14pt para mejorar su lectura.

## Testing
- `npm test` (falla: package.json no encontrado)


------
https://chatgpt.com/codex/tasks/task_e_68b10fefb9bc832cb592170b15600790